### PR TITLE
Upgrade packages & catch exceptions in GuildEventMonitorService loop

### DIFF
--- a/src/Miha.Discord/Miha.Discord.csproj
+++ b/src/Miha.Discord/Miha.Discord.csproj
@@ -10,10 +10,10 @@
   <ItemGroup>
     <PackageReference Include="Cronos" Version="0.8.4" />
     <PackageReference Include="Discord.Addons.Hosting" Version="6.1.0" />
-    <PackageReference Include="Discord.Net" Version="3.15.2" />
+    <PackageReference Include="Discord.Net" Version="3.16.0" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
-    <PackageReference Include="SlimMessageBus" Version="2.0.2" />
-    <PackageReference Include="SlimMessageBus.Host.Memory" Version="2.3.5" />
+    <PackageReference Include="SlimMessageBus" Version="2.0.4" />
+    <PackageReference Include="SlimMessageBus.Host.Memory" Version="2.5.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Miha.Logic/Miha.Logic.csproj
+++ b/src/Miha.Logic/Miha.Logic.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Discord.Addons.Hosting" Version="6.1.0" />
-    <PackageReference Include="Discord.Net" Version="3.15.2" />
+    <PackageReference Include="Discord.Net" Version="3.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Miha.Redis/Miha.Redis.csproj
+++ b/src/Miha.Redis/Miha.Redis.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="FluentResults" Version="3.16.0" />
     <PackageReference Include="FluentResults.Extensions.FluentAssertions" Version="2.1.2" />
-    <PackageReference Include="Redis.OM" Version="0.7.1" />
+    <PackageReference Include="Redis.OM" Version="0.7.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Miha.Shared/Miha.Shared.csproj
+++ b/src/Miha.Shared/Miha.Shared.csproj
@@ -17,13 +17,13 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="NodaTime" Version="3.1.11" />
+    <PackageReference Include="NodaTime" Version="3.1.12" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.2.0" />
-    <PackageReference Include="Serilog" Version="4.0.0" />
+    <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
   </ItemGroup>


### PR DESCRIPTION
# Motivations
GuildEventMonitorService keeps failing when it encounters a total request drop from either Discord or the client

# Modifications
- Upgrade all packages to latest
- Add a `try` `catch` to `GuildEventMonitorService` in hopes of assuring the entire background service doesn't fail at random whenever packets get dropped